### PR TITLE
Use X-Forwarded-For header for instance, if present

### DIFF
--- a/handler/push.go
+++ b/handler/push.go
@@ -159,10 +159,15 @@ func LegacyPush(
 				return
 			}
 			if instance == "" {
-				// Remote IP number (without port).
-				instance, _, err = net.SplitHostPort(r.RemoteAddr)
-				if err != nil || instance == "" {
-					instance = "localhost"
+				if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
+					// Use X-Forwarded-For header
+					instance = xff
+				} else {
+					// Remote IP number (without port).
+					instance, _, err = net.SplitHostPort(r.RemoteAddr)
+					if err != nil || instance == "" {
+						instance = "localhost"
+					}
 				}
 			}
 			labels := map[string]string{"job": job, "instance": instance}


### PR DESCRIPTION
When pushgateway is behind a proxy, all traffic appears to come from the proxy. This patch uses the X-Forwarded-For header as the instance info, if the proxy adds it.